### PR TITLE
Fix binding extensions not being installed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,12 @@ steps:
 
   - script: npm ci
 
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: 'build'
+      projects: 'extensions.csproj'
+      arguments: '--output $(Build.SourcesDirectory)/bin'
+
   - task: NuGetCommand@2
     displayName: 'NuGet pack'
     inputs:


### PR DESCRIPTION
Runs dotnet install to add the packages.

Pipeline is failing because someone's deleted the nuget feed out the build (i have no clue why someone's configured this so that it tries to push to nuget as part of CI)