### PR TITLE
Fix/ignore approval status for non display group workflows

### DIFF
--- a/ImportTimeseriesRouter/helpers/is-task-run-approved.js
+++ b/ImportTimeseriesRouter/helpers/is-task-run-approved.js
@@ -1,10 +1,10 @@
 const extract = require('../../Shared/extract')
 
-module.exports = async function isTaskRunApproved (context, preparedStatement, message) {
+module.exports = async function isTaskRunApproved (context, preparedStatement, message, throwExceptionOnNonMatch) {
   const isMadeCurrentManuallyMessage = 'is made current manually'
   // Test for automatic and manual task run approval.
   const taskRunApprovedRegex = new RegExp(`(?:Approved\\:?\\s*)True|False|${isMadeCurrentManuallyMessage}`, 'i')
   const taskRunApprovedText = 'task run approval status'
-  const taskRunApprovedString = await extract(context, message, taskRunApprovedRegex, 1, 0, taskRunApprovedText, preparedStatement)
+  const taskRunApprovedString = await extract(context, message, taskRunApprovedRegex, 1, 0, taskRunApprovedText, preparedStatement, throwExceptionOnNonMatch)
   return taskRunApprovedString && !!taskRunApprovedString.match(new RegExp(`true|${isMadeCurrentManuallyMessage}`, 'i'))
 }

--- a/ImportTimeseriesRouter/index.js
+++ b/ImportTimeseriesRouter/index.js
@@ -11,27 +11,25 @@ const sql = require('mssql')
 
 module.exports = async function (context, message) {
   // This function is triggered via a queue message drop, 'message' is the name of the variable that contains the queue item payload
-  context.log.info('JavaScript import time series function processed work item', message)
+  context.log.info('JavaScript import time series function processing work item', message)
   context.log.info(context.bindingData)
 
   async function routeMessage (transaction, context) {
-    context.log('JavaScript router ServiceBus queue trigger function processed message', message)
-    const proceedWithImport = await executePreparedStatementInTransaction(isTaskRunApproved, context, transaction, message)
-    if (proceedWithImport) {
-      const routeData = {
-      }
-      // Retrieve data from twelve hours before the task run completed to five days after the task run completed by default.
-      // This time period can be overridden by the two environment variables
-      // FEWS_START_TIME_OFFSET_HOURS and FEWS_END_TIME_OFFSET_HOURS.
-      const startTimeOffsetHours = process.env['FEWS_START_TIME_OFFSET_HOURS'] ? parseInt(process.env['FEWS_START_TIME_OFFSET_HOURS']) : 12
-      const endTimeOffsetHours = process.env['FEWS_END_TIME_OFFSET_HOURS'] ? parseInt(process.env['FEWS_END_TIME_OFFSET_HOURS']) : 120
-      routeData.taskCompletionTime = await executePreparedStatementInTransaction(getTaskRunCompletionDate, context, transaction, message)
-      routeData.startTime = moment(routeData.taskCompletionTime).subtract(startTimeOffsetHours, 'hours').toISOString()
-      routeData.endTime = moment(routeData.taskCompletionTime).add(endTimeOffsetHours, 'hours').toISOString()
-      routeData.workflowId = await executePreparedStatementInTransaction(getWorkflowId, context, transaction, message)
-      routeData.taskId = await executePreparedStatementInTransaction(getTaskRunId, context, transaction, message)
-      routeData.transaction = transaction
+    const routeData = {
+    }
+    // Retrieve data from twelve hours before the task run completed to five days after the task run completed by default.
+    // This time period can be overridden by the two environment variables
+    // FEWS_START_TIME_OFFSET_HOURS and FEWS_END_TIME_OFFSET_HOURS.
+    const startTimeOffsetHours = process.env['FEWS_START_TIME_OFFSET_HOURS'] ? parseInt(process.env['FEWS_START_TIME_OFFSET_HOURS']) : 12
+    const endTimeOffsetHours = process.env['FEWS_END_TIME_OFFSET_HOURS'] ? parseInt(process.env['FEWS_END_TIME_OFFSET_HOURS']) : 120
+    routeData.taskCompletionTime = await executePreparedStatementInTransaction(getTaskRunCompletionDate, context, transaction, message)
+    routeData.startTime = moment(routeData.taskCompletionTime).subtract(startTimeOffsetHours, 'hours').toISOString()
+    routeData.endTime = moment(routeData.taskCompletionTime).add(endTimeOffsetHours, 'hours').toISOString()
+    routeData.workflowId = await executePreparedStatementInTransaction(getWorkflowId, context, transaction, message)
+    routeData.taskId = await executePreparedStatementInTransaction(getTaskRunId, context, transaction, message)
+    routeData.transaction = transaction
 
+    if (routeData.taskCompletionTime && routeData.workflowId && routeData.taskId) {
       routeData.fluvialDisplayGroupWorkflowsResponse =
         await executePreparedStatementInTransaction(getFluvialDisplayGroupWorkflows, context, transaction, routeData.workflowId)
 
@@ -42,8 +40,6 @@ module.exports = async function (context, message) {
         await executePreparedStatementInTransaction(getIgnoredWorkflows, context, transaction, routeData.workflowId)
 
       await route(context, message, routeData)
-    } else {
-      context.log.warn(`Ignoring message ${JSON.stringify(message)}`)
     }
   }
   await doInTransaction(routeMessage, context, 'The message routing function has failed with the following error:', sql.ISOLATION_LEVEL.SERIALIZABLE)
@@ -213,20 +209,42 @@ async function route (context, message, routeData) {
         routeData
       )
 
-      if (routeData.fluvialDisplayGroupWorkflowsResponse.recordset.length > 0) {
-        context.log.info('Message routed to the plot function')
-        timeseriesData = await getTimeSeriesDisplayGroups(context, routeData)
-      } else if (routeData.fluvialNonDisplayGroupWorkflowsResponse.recordset.length > 0) {
-        context.log.info('Message has been routed to the filter function')
-        timeseriesData = await getTimeSeriesNonDisplayGroups(context, routeData)
+      try {
+        // Check if the task run is approved, forcing an exception to be thrown if the approval status cannot be determined.
+        let proceedWithImport = await executePreparedStatementInTransaction(isTaskRunApproved, context, routeData.transaction, message, true)
+
+        if (routeData.fluvialDisplayGroupWorkflowsResponse.recordset.length > 0) {
+          // Do not import data for unapproved task runs of display group workflows.
+          if (proceedWithImport) {
+            context.log.info('Message routed to the plot function')
+            timeseriesData = await getTimeSeriesDisplayGroups(context, routeData)
+          }
+        } else if (routeData.fluvialNonDisplayGroupWorkflowsResponse.recordset.length > 0) {
+          // Data for task runs of non-display group workflows must be imported regardless of approval status.
+          proceedWithImport = true
+          context.log.info('Message has been routed to the filter function')
+          timeseriesData = await getTimeSeriesNonDisplayGroups(context, routeData)
+        }
+
+        if (proceedWithImport) {
+          await executePreparedStatementInTransaction(
+            loadTimeseries,
+            context,
+            routeData.transaction,
+            timeseriesData,
+            routeData
+          )
+        } else {
+          context.log.warn(`Ignoring message ${JSON.stringify(message)}`)
+        }
+      } catch (err) {
+        if (err.message && !err.message.includes(' does not match regular expression')) {
+          // Propagate the exception if it was thrown for a reason other than failure to match a regular expresssion.
+          // Failure to match a regular expression causes creation of a staging exception database record.  In this case,
+          // an exception should not be propagated.
+          throw err
+        }
       }
-      await executePreparedStatementInTransaction(
-        loadTimeseries,
-        context,
-        routeData.transaction,
-        timeseriesData,
-        routeData
-      )
     } else {
       const errorMessage =
        routeData.workflowId ? `Missing PI Server input data for ${routeData.workflowId}`

--- a/Shared/extract.js
+++ b/Shared/extract.js
@@ -1,6 +1,6 @@
 const createStagingException = require('./create-staging-exception')
 
-module.exports = async function (context, message, regex, expectedNumberOfMatches, matchIndexToReturn, errorMessageSubject, preparedStatement) {
+module.exports = async function (context, message, regex, expectedNumberOfMatches, matchIndexToReturn, errorMessageSubject, preparedStatement, throwExceptionOnNonMatch) {
   const matches = regex.exec(message)
   // If the message contains the expected number of matches from the specified regular expression return
   // the match indicated by the caller.
@@ -11,5 +11,9 @@ module.exports = async function (context, message, regex, expectedNumberOfMatche
     // format and cannot be replayed. In this case intervention is needed so create a staging
     // exception.
     await createStagingException(context, preparedStatement, message, `Unable to extract ${errorMessageSubject} from message`)
+
+    if (throwExceptionOnNonMatch) {
+      throw new Error(`Message ${message} does not match regular expression ${regex}}`)
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2643,8 +2643,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2665,14 +2664,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2687,20 +2684,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2817,8 +2811,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2830,7 +2823,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2845,7 +2837,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2853,14 +2844,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2879,7 +2868,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2969,8 +2957,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2982,7 +2969,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3068,8 +3054,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3105,7 +3090,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3125,7 +3109,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3169,14 +3152,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/testing/messages/task-run-complete/non-display-group-messages.json
+++ b/testing/messages/task-run-complete/non-display-group-messages.json
@@ -55,5 +55,14 @@
       "source": "ukeafffsmc00:000000001",
       "level": "INFO"
     }
+  },
+  "forecastWithoutEndTime": {
+    "input": {
+      "code": "TASKRUN.Complete",
+      "entryTime": 1568379065,
+      "description": "Task  Test_Workflow1 with ID ukeafffsmc00:000000001 completed in 5s Forecast: True Approved: True Start time: 2019-09-13 13:05:00 More text",
+      "source": "ukeafffsmc00:000000001",
+      "level": "INFO"
+    }
   }
 }


### PR DESCRIPTION
Ignore approval status of task runs for non-display group workflows as part of https://eaflood.atlassian.net/browse/IWP-353