### PR TITLE
Fix/pipeline - Work around DateTimeOffset error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,8 @@ steps:
   - script: npm run build
   - script: npx markdownlint $PWD --ignore node_modules
   - script: npm test
-  - script: ls -la
+  - script: find ./node_modules -print -exec touch {} \;
+  - script: ls -ltd $(find .)
 
   - task: NuGetCommand@2
     displayName: 'NuGet pack'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ steps:
   - script: npm run build
   - script: npx markdownlint $PWD --ignore node_modules
   - script: npm test
+  - script: ls -la
 
   - task: NuGetCommand@2
     displayName: 'NuGet pack'


### PR DESCRIPTION
Timestamps found in node_modules vary between 1970-1985 which is causing nuget pack to fail. 

Touching ./node_modules resets the timestamp and allows nuget pack to complete. 
A workaround until a better fix is found.
