### PR TITLE
Fix/java11 environment variable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,10 @@ steps:
     inputs:
       versionSpec: '10.x' # replace this value with the version that you need for your project
 
+  - script: |
+    echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+    echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin:$(PATH)"
+  displayName: "Set java version"
   - script: npm ci
   - script: npm run build
   - script: npx markdownlint $PWD --ignore node_modules

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,8 @@ steps:
       versionSpec: '10.x' # replace this value with the version that you need for your project
 
   - script: |
-    echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
-    echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin:$(PATH)"
+        echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+        echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin:$(PATH)"
   - script: npm ci
   - script: npm run build
   - script: npx markdownlint $PWD --ignore node_modules

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,6 @@ steps:
   - script: |
     echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
     echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin:$(PATH)"
-  displayName: "Set java version"
   - script: npm ci
   - script: npm run build
   - script: npx markdownlint $PWD --ignore node_modules


### PR DESCRIPTION
Change JAVA environment variable;
from default;
1.8.0_265 | AdoptOpenJDK | JAVA_HOME_8_X64
to
11.0.8 | AdoptOpenJDK | JAVA_HOME_11_X64

This can be found from Azure DevOps documentation for hosted agents;
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1604-README.md

So that JAVA11 can be used instead.
