### PR TITLE
Allow replay of core engine messages containing invalid JSON

### DIFF
--- a/ReplayProcessFewsEventCode/index.js
+++ b/ReplayProcessFewsEventCode/index.js
@@ -1,4 +1,17 @@
 module.exports = async function (context, message) {
   context.log(`Replaying ${message}`)
-  context.bindings.processFewsEventCode = message
+  // If JSON parsing fails when a message is sent to the fews-eventcode queue the message
+  // will remain on the dead letter queue. It seems that some core forecasting engine messages
+  // can contain invalid JSON, causing this scanario. To workaround this temporarily, try and parse
+  // the message as JSON before replay is attempted. If parsing fails, stringify the message before replaying it.
+  let messageToReplay = message
+
+  if (message.constructor.name === 'String') {
+    try {
+      JSON.parse(message)
+    } catch (err) {
+      messageToReplay = JSON.stringify(message)
+    }
+  }
+  context.bindings.processFewsEventCode = messageToReplay
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "future-flood-forecasting-web-portal-importer",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "A set of Node.js Microsoft Azure functions for the import of flood forecasting data.",
   "scripts": {
     "build": "build/src/main/resources/scripts/build.sh",

--- a/testing/function-tests/ReplayProcessFewsEventCode/test.index.js
+++ b/testing/function-tests/ReplayProcessFewsEventCode/test.index.js
@@ -26,9 +26,17 @@ module.exports = describe('Tests for replaying messages on the ProcessFewsEventC
       await commonTimeseriesTestUtils.afterAll(pool)
     })
 
-    it('should transfer messages to the fews-eventcode-queue', async () => {
+    it('should transfer messages containing valid JSON to the fews-eventcode-queue', async () => {
       await replayProcessFewsEventCode(context, messages['singlePlotApprovedForecast'])
       expect(context.bindings.processFewsEventCode).toBe(messages['singlePlotApprovedForecast'])
+    })
+
+    it('should transfer messages containing invalid JSON to the fews-eventcode-queue', async () => {
+      // Ensure the message contains invalid JSON.
+      const message = '{ "message": "A:\\\Path"}' // eslint-disable-line
+      const stringifiedMessage = JSON.stringify(message)
+      await replayProcessFewsEventCode(context, message)
+      expect(context.bindings.processFewsEventCode).toBe(stringifiedMessage)
     })
   })
 })


### PR DESCRIPTION
Part of https://eaflood.atlassian.net/browse/IWP-638