### PR TITLE
Feature/support null value datums

### DIFF
--- a/RefreshFluvialForecastLocationData/index.js
+++ b/RefreshFluvialForecastLocationData/index.js
@@ -18,7 +18,7 @@ module.exports = async function (context) {
       { tableColumnName: 'FFFS_LOCATION_ID', tableColumnType: 'NVarChar', expectedCSVKey: 'FFFSLocID' },
       { tableColumnName: 'FFFS_LOCATION_NAME', tableColumnType: 'NVarChar', expectedCSVKey: 'FFFSLocName' },
       { tableColumnName: 'DRN_ORDER', tableColumnType: 'Int', expectedCSVKey: 'DRNOrder' },
-      { tableColumnName: 'DATUM', tableColumnType: 'NVarChar', expectedCSVKey: 'Datum' },
+      { tableColumnName: 'DATUM', tableColumnType: 'NVarChar', expectedCSVKey: 'Datum', nullValueOverride: true },
       { tableColumnName: 'DISPLAY_ORDER', tableColumnType: 'Int', expectedCSVKey: 'Order' },
       { tableColumnName: 'CENTRE', tableColumnType: 'NVarChar', expectedCSVKey: 'Centre' },
       { tableColumnName: 'PLOT_ID', tableColumnType: 'NVarChar', expectedCSVKey: 'PlotID' },

--- a/RefreshMVTData/index.js
+++ b/RefreshMVTData/index.js
@@ -35,7 +35,7 @@ function parseBooleanString (booleanString) {
 }
 
 function returnNullForNaN (value) {
-  if (isNaN(value) || value === '') {
+  if (isNaN(value)) {
     return null
   } else {
     return value

--- a/Shared/shared-refresh-csv-rows.js
+++ b/Shared/shared-refresh-csv-rows.js
@@ -104,10 +104,14 @@ async function buildPreparedStatementParameters (context, row, refreshData) {
     const expectedCsvKey = columnObject.expectedCSVKey
 
     if (row[expectedCsvKey] || columnObject.nullValueOverride === true) {
+      let rowData = row[expectedCsvKey]
+      if (columnObject.nullValueOverride === true && (row[expectedCsvKey] === null || row[expectedCsvKey] === '')) {
+        rowData = null
+      }
       if (columnObject.preprocessor) {
-        preparedStatementExecuteObject[columnName] = columnObject.preprocessor(row[expectedCsvKey], columnName)
+        preparedStatementExecuteObject[columnName] = columnObject.preprocessor(rowData, columnName)
       } else {
-        preparedStatementExecuteObject[columnName] = row[expectedCsvKey]
+        preparedStatementExecuteObject[columnName] = rowData
       }
     } else {
       return { rowError: true }

--- a/Shared/shared-refresh-csv-rows.js
+++ b/Shared/shared-refresh-csv-rows.js
@@ -122,8 +122,8 @@ async function buildPreparedStatementParameters (context, row, refreshData) {
 
 async function processCsvRow (context, preparedStatement, row, refreshData) {
   try {
-    const result = await buildPreparedStatementParameters(context, row, refreshData)
-    if (result.rowError) {
+    const rowExecuteObject = await buildPreparedStatementParameters(context, row, refreshData)
+    if (rowExecuteObject.rowError) {
       context.log.warn('row is missing data.')
       const failedRowInfo = {
         rowData: row,
@@ -132,7 +132,7 @@ async function processCsvRow (context, preparedStatement, row, refreshData) {
       }
       refreshData.failedCsvRows.push(failedRowInfo)
     } else {
-      await preparedStatement.execute(result)
+      await preparedStatement.execute(rowExecuteObject)
     }
   } catch (err) {
     context.log.warn(`An error has been found in a row.\nError : ${err}.`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "future-flood-forecasting-web-portal-importer",
-  "version": "0.18.1",
+  "version": "0.18.0",
   "description": "A set of Node.js Microsoft Azure functions for the import of flood forecasting data.",
   "scripts": {
     "build": "build/src/main/resources/scripts/build.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "future-flood-forecasting-web-portal-importer",
-  "version": "0.17.1",
+  "version": "0.18.1",
   "description": "A set of Node.js Microsoft Azure functions for the import of flood forecasting data.",
   "scripts": {
     "build": "build/src/main/resources/scripts/build.sh",

--- a/testing/function-tests/RefreshFluvialForecastLocationData/fluvial_forecast_location_files/valid-null-datum.csv
+++ b/testing/function-tests/RefreshFluvialForecastLocationData/fluvial_forecast_location_files/valid-null-datum.csv
@@ -1,0 +1,2 @@
+CatchmentOrder,Centre,MFDOArea,Catchment,FFFSLocID,FFFSLocName,PlotID,DRNOrder,Order,Datum
+1,Birmingham,Derbyshire Nottinghamshire and Leicestershire,Derwent,40443,CHATSWORTH,Fluvial_Gauge_MFDO,123,8988,

--- a/testing/function-tests/RefreshFluvialForecastLocationData/test.index.js
+++ b/testing/function-tests/RefreshFluvialForecastLocationData/test.index.js
@@ -377,7 +377,7 @@ module.exports = describe('Refresh forecast location data tests', () => {
             and CATCHMENT = '${Catchment}' and FFFS_LOCATION_ID = '${FFFSLocID}' and CATCHMENT_ORDER = '${CatchmentOrder}'
             and FFFS_LOCATION_NAME = '${FFFSLocName}' and FFFS_LOCATION_ID = '${FFFSLocID}'
             and PLOT_ID = '${PlotId}' and DRN_ORDER = '${DRNOrder}' and DATUM = '${Datum}' and DISPLAY_ORDER = '${DisplayOrder}'
-      `)
+        `)
         expect(databaseResult.recordset[0].number).toEqual(1)
       }
     }

--- a/testing/function-tests/RefreshFluvialForecastLocationData/test.index.js
+++ b/testing/function-tests/RefreshFluvialForecastLocationData/test.index.js
@@ -291,12 +291,38 @@ module.exports = describe('Refresh forecast location data tests', () => {
       await expect(messageFunction(context, message)).rejects.toEqual(expectedError)
       await checkExpectedResults(expectedData, expectedNumberOfExceptionRows)
     })
+
+    it('should refresh given a valid CSV file with a null datum value', async () => {
+      const mockResponseData = {
+        statusCode: STATUS_CODE_200,
+        filename: 'valid-null-datum.csv',
+        statusText: STATUS_TEXT_OK,
+        contentType: TEXT_CSV
+      }
+
+      const expectedForecastLocationData = [{
+        Centre: 'Birmingham',
+        MFDOArea: 'Derbyshire Nottinghamshire and Leicestershire',
+        Catchment: 'Derwent',
+        FFFSLocID: '40443',
+        FFFSLocName: 'CHATSWORTH',
+        PlotId: 'Fluvial_Gauge_MFDO',
+        DRNOrder: 123,
+        Order: 8988,
+        Datum: '',
+        CatchmentOrder: 1
+      }]
+      const expectedNumberOfExceptionRows = 0
+      // We cannot check for a null value with a WHERE clause, therefore just check the row has successfully inserted into the table.
+      const skipDetailedCheck = true
+      await refreshForecastLocationDataAndCheckExpectedResults(mockResponseData, expectedForecastLocationData, expectedNumberOfExceptionRows, skipDetailedCheck)
+    })
   })
 
-  async function refreshForecastLocationDataAndCheckExpectedResults (mockResponseData, expectedForecastLocationData, expectedNumberOfExceptionRows) {
+  async function refreshForecastLocationDataAndCheckExpectedResults (mockResponseData, expectedForecastLocationData, expectedNumberOfExceptionRows, skipDetailedCheck) {
     await mockFetchResponse(mockResponseData)
     await messageFunction(context, message) // calling actual function here
-    await checkExpectedResults(expectedForecastLocationData, expectedNumberOfExceptionRows)
+    await checkExpectedResults(expectedForecastLocationData, expectedNumberOfExceptionRows, skipDetailedCheck)
   }
 
   async function mockFetchResponse (mockResponseData) {
@@ -312,7 +338,7 @@ module.exports = describe('Refresh forecast location data tests', () => {
     fetch.mockResolvedValue(mockResponse)
   }
 
-  async function checkExpectedResults (expectedForecastLocationData, expectedNumberOfExceptionRows) {
+  async function checkExpectedResults (expectedForecastLocationData, expectedNumberOfExceptionRows, skipDetailedCheck) {
     const result = await request.query(`
     select 
       count(*) 
@@ -326,7 +352,7 @@ module.exports = describe('Refresh forecast location data tests', () => {
     expect(result.recordset[0].number).toBe(expectedNumberOfRows)
     context.log(`Live data row count: ${result.recordset[0].number}, test data row count: ${expectedNumberOfRows}`)
 
-    if (expectedNumberOfRows > 0) {
+    if (expectedNumberOfRows > 0 && !skipDetailedCheck) {
       for (const row of expectedForecastLocationData) {
         const Centre = row.Centre
         const MFDOArea = row.MFDOArea
@@ -335,21 +361,22 @@ module.exports = describe('Refresh forecast location data tests', () => {
         const FFFSLocName = row.FFFSLocName
         const PlotId = row.PlotId
         const DRNOrder = row.DRNOrder
-        const displayOrder = row.Order
-        const catchmentOrder = row.CatchmentOrder
+        const DisplayOrder = row.Order
+        const Datum = row.Datum
+        const CatchmentOrder = row.CatchmentOrder
 
         const databaseResult = await request.query(`
-      select 
-        count(*) 
-      as 
-        number 
-      from 
-        fff_staging.fluvial_forecast_location
-      where 
-        CENTRE = '${Centre}' and MFDO_AREA = '${MFDOArea}'
-        and CATCHMENT = '${Catchment}' and FFFS_LOCATION_ID = '${FFFSLocID}' and CATCHMENT_ORDER = '${catchmentOrder}'
-        and FFFS_LOCATION_NAME = '${FFFSLocName}' and FFFS_LOCATION_ID = '${FFFSLocID}'
-      and PLOT_ID = '${PlotId}' and DRN_ORDER = '${DRNOrder}' and DISPLAY_ORDER = '${displayOrder}'
+          select 
+            count(*) 
+          as 
+            number 
+          from 
+            fff_staging.fluvial_forecast_location
+          where 
+            CENTRE = '${Centre}' and MFDO_AREA = '${MFDOArea}'
+            and CATCHMENT = '${Catchment}' and FFFS_LOCATION_ID = '${FFFSLocID}' and CATCHMENT_ORDER = '${CatchmentOrder}'
+            and FFFS_LOCATION_NAME = '${FFFSLocName}' and FFFS_LOCATION_ID = '${FFFSLocID}'
+            and PLOT_ID = '${PlotId}' and DRN_ORDER = '${DRNOrder}' and DATUM = '${Datum}' and DISPLAY_ORDER = '${DisplayOrder}'
       `)
         expect(databaseResult.recordset[0].number).toEqual(1)
       }

--- a/testing/function-tests/RefreshMVTData/mvt_files/valid-with-NaN-bound-values.csv
+++ b/testing/function-tests/RefreshMVTData/mvt_files/valid-with-NaN-bound-values.csv
@@ -1,0 +1,3 @@
+Centre,criticalConditionID,outputLocationID,TargetAreaCode,inputLocationID,inputParameterID,lowerBoundInclusive,lowerBound,upperBoundInclusive,upperBound,Priority
+CENTRE1,dummy,dummy,dummy,dummy,dummy,0,NaN1,1,NaN2,9
+CENTRE2,dummy,dummy,dummy,dummy,dummy,0,NaN3,0,NaN4,1

--- a/testing/function-tests/RefreshNonDisplayGroupData/test.index.js
+++ b/testing/function-tests/RefreshNonDisplayGroupData/test.index.js
@@ -235,7 +235,7 @@ module.exports = describe('Insert non_display_group_workflow data tests', () => 
       const expectedErrorDescription = 'row is missing data.'
 
       const expectedNonDisplayGroupData = {
-        test_non_display_workflow_2: [{ filterId: 'test_filter_a', approved: 0, startTimeOffset: 0, endTimeOffset: 0, timeSeriesType: EXTERNAL_HISTORICAL }]
+        test_non_display_workflow_2: [{ filterId: 'test_filter_a', approved: 0, startTimeOffset: null, endTimeOffset: null, timeSeriesType: EXTERNAL_HISTORICAL }]
       }
 
       const expectedData = {
@@ -324,7 +324,7 @@ module.exports = describe('Insert non_display_group_workflow data tests', () => 
         contentType: TEXT_CSV
       }
       const expectedNonDisplayGroupData = {
-        test_non_display_workflow_1: [{ filterId: 'test_filter_1', approved: 0, startTimeOffset: 0, endTimeOffset: 0, timeSeriesType: EXTERNAL_HISTORICAL }]
+        test_non_display_workflow_1: [{ filterId: 'test_filter_1', approved: 0, startTimeOffset: null, endTimeOffset: null, timeSeriesType: EXTERNAL_HISTORICAL }]
       }
       const expectedErrorDescription = 'row is missing data.'
       const expectedData = {
@@ -344,8 +344,8 @@ module.exports = describe('Insert non_display_group_workflow data tests', () => 
       }
 
       const expectedNonDisplayGroupData = {
-        test_non_display_workflow_3: [{ filterId: 'test_filter_3', approved: 0, startTimeOffset: 0, endTimeOffset: 0, timeSeriesType: EXTERNAL_HISTORICAL }],
-        test_non_display_workflow_2: [{ filterId: 'test_filter_2', approved: 1, startTimeOffset: 0, endTimeOffset: 0, timeSeriesType: EXTERNAL_HISTORICAL }]
+        test_non_display_workflow_3: [{ filterId: 'test_filter_3', approved: 0, startTimeOffset: null, endTimeOffset: null, timeSeriesType: EXTERNAL_HISTORICAL }],
+        test_non_display_workflow_2: [{ filterId: 'test_filter_2', approved: 1, startTimeOffset: null, endTimeOffset: null, timeSeriesType: EXTERNAL_HISTORICAL }]
       }
 
       const expectedData = {

--- a/testing/staging-database/bootstrap.sh
+++ b/testing/staging-database/bootstrap.sh
@@ -3,7 +3,7 @@
 if  ! `nc -z $SQLTESTDB_HOST $SQLTESTDB_PORT`; then
   cd testing/staging-database
   rm -rf future-flood-forecasting-web-portal-staging
-  git clone https://github.com/DEFRA/future-flood-forecasting-web-portal-staging.git
+  git clone -b feature/support-null-value-datums https://github.com/DEFRA/future-flood-forecasting-web-portal-staging.git
   cd future-flood-forecasting-web-portal-staging
   ./local-bootstrap.sh
 fi

--- a/testing/staging-database/bootstrap.sh
+++ b/testing/staging-database/bootstrap.sh
@@ -3,7 +3,7 @@
 if  ! `nc -z $SQLTESTDB_HOST $SQLTESTDB_PORT`; then
   cd testing/staging-database
   rm -rf future-flood-forecasting-web-portal-staging
-  git clone -b feature/support-null-value-datums https://github.com/DEFRA/future-flood-forecasting-web-portal-staging.git
+  git clone https://github.com/DEFRA/future-flood-forecasting-web-portal-staging.git
   cd future-flood-forecasting-web-portal-staging
   ./local-bootstrap.sh
 fi


### PR DESCRIPTION
Change the handling of the datum values in ForecastTree Order csv to allow null values in staging

https://eaflood.atlassian.net/browse/IWP-698

Allow null value datums in the FLUVIAL_FORECAST_LOCATION table.