### PR TITLE
Fix/csv load deadlock

### DIFF
--- a/Shared/csv-load/shared-refresh-csv-rows.js
+++ b/Shared/csv-load/shared-refresh-csv-rows.js
@@ -14,7 +14,7 @@ module.exports = async function (context, refreshData) {
   // In most cases function invocation will be retried automatically and should succeed.  In rare
   // cases where successive retries fail, the message that triggers the function invocation will be
   // placed on a dead letter queue.  In this case, manual intervention will be required.
-  await doInTransaction(refreshInTransaction, context, `The ${refreshData.csvSourceFile} refresh has failed with the following error:`, sql.ISOLATION_LEVEL.READ_COMMITTED, refreshData)
+  await doInTransaction(refreshInTransaction, context, `The ${refreshData.csvSourceFile} refresh has failed with the following error:`, sql.ISOLATION_LEVEL.SERIALIZABLE, refreshData)
 
   // Transaction 2
   // If a rollback has occurred, workflow refresh and message replay should not occur.
@@ -132,7 +132,7 @@ async function processCsvRow (context, preparedStatement, row, refreshData) {
   try {
     const rowExecuteObject = await buildPreparedStatementParameters(context, row, refreshData)
     if (rowExecuteObject.rowError) {
-      context.log.warn('row is missing data.')
+      // context.log.warn('row is missing data.')
       const failedRowInfo = {
         rowData: row,
         errorMessage: 'row is missing data.',

--- a/Shared/csv-load/shared-refresh-csv-rows.js
+++ b/Shared/csv-load/shared-refresh-csv-rows.js
@@ -132,7 +132,7 @@ async function processCsvRow (context, preparedStatement, row, refreshData) {
   try {
     const rowExecuteObject = await buildPreparedStatementParameters(context, row, refreshData)
     if (rowExecuteObject.rowError) {
-      // context.log.warn('row is missing data.')
+      context.log.warn('row is missing data.')
       const failedRowInfo = {
         rowData: row,
         errorMessage: 'row is missing data.',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "future-flood-forecasting-web-portal-importer",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "A set of Node.js Microsoft Azure functions for the import of flood forecasting data.",
   "scripts": {
     "build": "build/src/main/resources/scripts/build.sh",

--- a/testing/function-tests/RefreshCoastalDisplayGroupData/test.index.js
+++ b/testing/function-tests/RefreshCoastalDisplayGroupData/test.index.js
@@ -108,8 +108,9 @@ module.exports = describe('Insert coastal_display_group_workflow data tests', ()
         ]
       }
 
+      const expectWorkflowRefresh = true
       await commonWorkflowCsvTestUtils.insertWorkflowRefreshRecords()
-      await refreshCoastalDisplayGroupDataAndCheckExpectedResults(mockResponseData, expectedData)
+      await refreshCoastalDisplayGroupDataAndCheckExpectedResults(mockResponseData, expectedData, expectWorkflowRefresh)
     })
     it('should ignore a  CSV file with misspelled headers', async () => {
       const mockResponseData = {
@@ -181,8 +182,9 @@ module.exports = describe('Insert coastal_display_group_workflow data tests', ()
         numberOfExceptionRows: 1
       }
 
+      const expectWorkflowRefresh = true
       const expectedErrorDescription = 'row is missing data'
-      await refreshCoastalDisplayGroupDataAndCheckExpectedResults(mockResponseData, expectedData)
+      await refreshCoastalDisplayGroupDataAndCheckExpectedResults(mockResponseData, expectedData, expectWorkflowRefresh)
       await checkExceptionIsCorrect(expectedErrorDescription)
     })
     it('should omit all rows as there is missing values for the entire column', async () => {
@@ -297,10 +299,10 @@ module.exports = describe('Insert coastal_display_group_workflow data tests', ()
     })
   })
 
-  async function refreshCoastalDisplayGroupDataAndCheckExpectedResults (mockResponseData, expectedData) {
+  async function refreshCoastalDisplayGroupDataAndCheckExpectedResults (mockResponseData, expectedData, expectWorkflowRefresh) {
     await mockFetchResponse(mockResponseData)
     await messageFunction(context, message) // This is a call to the function index
-    await checkExpectedResults(expectedData)
+    await checkExpectedResults(expectedData, expectWorkflowRefresh)
   }
 
   async function mockFetchResponse (mockResponseData) {
@@ -316,7 +318,7 @@ module.exports = describe('Insert coastal_display_group_workflow data tests', ()
     fetch.mockResolvedValue(mockResponse)
   }
 
-  async function checkExpectedResults (expectedData) {
+  async function checkExpectedResults (expectedData, expectWorkflowRefresh) {
     const tableCountResult = await request.query(`
       select 
         count(*) 
@@ -358,10 +360,10 @@ module.exports = describe('Insert coastal_display_group_workflow data tests', ()
         }
       }
 
-      if (expectedNumberOfRows > 1) {
+      if (typeof expectWorkflowRefresh !== 'undefined') {
         // If the CSV table is expected to contain rows other than the row of dummy data check that the workflow refresh table
         // contains a row for the CSV.
-        await commonWorkflowCsvTestUtils.checkWorkflowRefreshData()
+        await commonWorkflowCsvTestUtils.checkWorkflowRefreshData(expectWorkflowRefresh)
       }
     }
     // Check exceptions

--- a/testing/function-tests/RefreshFluvialDisplayGroupData/test.index.js
+++ b/testing/function-tests/RefreshFluvialDisplayGroupData/test.index.js
@@ -140,7 +140,8 @@ module.exports = describe('Insert fluvial_display_group_workflow data tests', ()
         ]
       }
 
-      await refreshDisplayGroupDataAndCheckExpectedResults(mockResponseData, expectedData)
+      const expectWorkflowRefresh = true
+      await refreshDisplayGroupDataAndCheckExpectedResults(mockResponseData, expectedData, expectWorkflowRefresh)
     })
 
     it('should group locations by plot ID and workflow ID given multiple combinations of workflowId and plotId', async () => {
@@ -163,7 +164,8 @@ module.exports = describe('Insert fluvial_display_group_workflow data tests', ()
         }
       }
 
-      await refreshDisplayGroupDataAndCheckExpectedResults(mockResponseData, expectedData)
+      const expectWorkflowRefresh = true
+      await refreshDisplayGroupDataAndCheckExpectedResults(mockResponseData, expectedData, expectWorkflowRefresh)
     })
 
     it('should not refresh with valid header row but no data rows', async () => {
@@ -311,10 +313,10 @@ module.exports = describe('Insert fluvial_display_group_workflow data tests', ()
     })
   })
 
-  async function refreshDisplayGroupDataAndCheckExpectedResults (mockResponseData, expectedData) {
+  async function refreshDisplayGroupDataAndCheckExpectedResults (mockResponseData, expectedData, expectWorkflowRefresh) {
     await mockFetchResponse(mockResponseData)
     await messageFunction(context, message)
-    await checkExpectedResults(expectedData)
+    await checkExpectedResults(expectedData, expectWorkflowRefresh)
   }
 
   async function mockFetchResponse (mockResponseData) {
@@ -330,7 +332,7 @@ module.exports = describe('Insert fluvial_display_group_workflow data tests', ()
     fetch.mockResolvedValue(mockResponse)
   }
 
-  async function checkExpectedResults (expectedData) {
+  async function checkExpectedResults (expectedData, expectWorkflowRefresh) {
     const result = await request.query(`
       select 
         count(*) 
@@ -375,10 +377,10 @@ module.exports = describe('Insert fluvial_display_group_workflow data tests', ()
           expect(dbLocations).toEqual(expectedLocationsArray)
         }
       }
-      if (expectedNumberOfRows > 1) {
+      if (typeof expectWorkflowRefresh !== 'undefined') {
         // If the CSV table is expected to contain rows other than the row of dummy data check that the workflow refresh table
         // contains a row for the CSV.
-        await commonWorkflowCsvTestUtils.checkWorkflowRefreshData()
+        await commonWorkflowCsvTestUtils.checkWorkflowRefreshData(expectWorkflowRefresh)
       }
     }
     // Check exceptions


### PR DESCRIPTION
Deadlock fix for CSV reference data load

https://eaflood.atlassian.net/browse/IWP-713

Functions the replay messages due to configuration updates are causing deadlocks and the transactions need to be managed to prevent blocking.